### PR TITLE
Follow-up #47

### DIFF
--- a/.github/workflows/singleuser-release.yaml
+++ b/.github/workflows/singleuser-release.yaml
@@ -26,6 +26,8 @@ jobs:
       JUPYTERHUB_VERSION: ${{github.event.inputs.jupyterhub_version}}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/singleuser-release.yaml
+++ b/.github/workflows/singleuser-release.yaml
@@ -1,4 +1,4 @@
-name: singleuser-relase
+name: singleuser-release
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/singleuser-release.yaml
+++ b/.github/workflows/singleuser-release.yaml
@@ -27,7 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          submodules: true
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/singleuser/config/before_start_hook.sh
+++ b/singleuser/config/before_start_hook.sh
@@ -16,6 +16,7 @@ if [[ ! -z "${DJLABHUB_REPO}" ]]; then
   if [[ ! -z "${DJLABHUB_REPO_BRANCH}" ]]; then
     echo "INFO::Switch to branch $DJLABHUB_REPO_BRANCH"
     git -C $HOME/$REPO_NAME switch $DJLABHUB_REPO_BRANCH || echo "WARNING::Failed to checkout branch ${DJLABHUB_REPO_BRANCH}. Continuing..."
+    cd $HOME/$REPO_NAME
     ls -lah
     git branch
   fi

--- a/singleuser/config/before_start_hook.sh
+++ b/singleuser/config/before_start_hook.sh
@@ -16,10 +16,6 @@ if [[ ! -z "${DJLABHUB_REPO}" ]]; then
   if [[ ! -z "${DJLABHUB_REPO_BRANCH}" ]]; then
     echo "INFO::Switch to branch $DJLABHUB_REPO_BRANCH"
     git -C $HOME/$REPO_NAME switch $DJLABHUB_REPO_BRANCH || echo "WARNING::Failed to checkout branch ${DJLABHUB_REPO_BRANCH}. Continuing..."
-    ls -lah
-    cd $HOME/$REPO_NAME
-    ls -lah
-    git branch
   fi
 
   if [[ $DJLABHUB_REPO_INSTALL == "TRUE" ]]; then

--- a/singleuser/config/before_start_hook.sh
+++ b/singleuser/config/before_start_hook.sh
@@ -15,7 +15,9 @@ if [[ ! -z "${DJLABHUB_REPO}" ]]; then
   git clone $DJLABHUB_REPO $HOME/$REPO_NAME || echo "WARNING::Failed to clone ${DJLABHUB_REPO}. Continuing..."
   if [[ ! -z "${DJLABHUB_REPO_BRANCH}" ]]; then
     echo "INFO::Switch to branch $DJLABHUB_REPO_BRANCH"
-    git -C $HOME/$REPO_NAME switch $DJLABHUB_REPO_BRANCH
+    git -C $HOME/$REPO_NAME switch $DJLABHUB_REPO_BRANCH || echo "WARNING::Failed to checkout branch ${DJLABHUB_REPO_BRANCH}. Continuing..."
+    ls -lah
+    git branch
   fi
 
   if [[ $DJLABHUB_REPO_INSTALL == "TRUE" ]]; then

--- a/singleuser/config/before_start_hook.sh
+++ b/singleuser/config/before_start_hook.sh
@@ -16,6 +16,10 @@ if [[ ! -z "${DJLABHUB_REPO}" ]]; then
   if [[ ! -z "${DJLABHUB_REPO_BRANCH}" ]]; then
     echo "INFO::Switch to branch $DJLABHUB_REPO_BRANCH"
     git -C $HOME/$REPO_NAME switch $DJLABHUB_REPO_BRANCH || echo "WARNING::Failed to checkout branch ${DJLABHUB_REPO_BRANCH}. Continuing..."
+    ls -lah
+    cd $HOME/$REPO_NAME
+    ls -lah
+    git branch
   fi
 
   if [[ $DJLABHUB_REPO_INSTALL == "TRUE" ]]; then

--- a/singleuser/config/before_start_hook.sh
+++ b/singleuser/config/before_start_hook.sh
@@ -16,9 +16,6 @@ if [[ ! -z "${DJLABHUB_REPO}" ]]; then
   if [[ ! -z "${DJLABHUB_REPO_BRANCH}" ]]; then
     echo "INFO::Switch to branch $DJLABHUB_REPO_BRANCH"
     git -C $HOME/$REPO_NAME switch $DJLABHUB_REPO_BRANCH || echo "WARNING::Failed to checkout branch ${DJLABHUB_REPO_BRANCH}. Continuing..."
-    cd $HOME/$REPO_NAME
-    ls -lah
-    git branch
   fi
 
   if [[ $DJLABHUB_REPO_INSTALL == "TRUE" ]]; then

--- a/singleuser/config/before_start_hook.sh
+++ b/singleuser/config/before_start_hook.sh
@@ -12,7 +12,7 @@ if [[ ! -z "${DJLABHUB_REPO}" ]]; then
   REPO_NAME=$(basename $DJLABHUB_REPO | sed 's/.git//')
 
   echo "INFO::Cloning repo $DJLABHUB_REPO"
-  git clone $DJLABHUB_REPO $HOME/$REPO_NAME
+  git clone $DJLABHUB_REPO $HOME/$REPO_NAME || echo "WARNING::Failed to clone ${DJLABHUB_REPO}. Continuing..."
   if [[ ! -z "${DJLABHUB_REPO_BRANCH}" ]]; then
     echo "INFO::Switch to branch $DJLABHUB_REPO_BRANCH"
     git -C $HOME/$REPO_NAME switch $DJLABHUB_REPO_BRANCH


### PR DESCRIPTION
singleuser CD fails when attempting to checkout submodule, e.g. [this CD job](https://github.com/datajoint/djlabhub-docker/actions/runs/9879488623/job/27285830965#step:4:635).

To fix, we need to run the checkout step with `submodule: true`, as we do with `works-api` CD: https://github.com/datajoint/djlabhub-docker
The value of SSH_PRIVATE_KEY is stored as `ipython-datajoint-creds-updater djlabhub` in LastPass.
I set the GitHub secret using:

```console
gh secret set SSH_PRIVATE_KEY < /home/eho/.ssh/ipython-datajoint-creds-updater-djlabhub
```
