### PR TITLE
Autoload extension on kernel start

### DIFF
--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -29,4 +29,4 @@ RUN \
     # remove default work directory
     [ -d "/home/jovyan/work" ] && rm -r /home/jovyan/work \
     # Install dependencies: pip
-    && pip install /tmp/ipython-datajoint-creds-updater -r /tmp/config/pip_requirements.txt jupyter_contrib_nbextensions
+    && pip install /tmp/ipython-datajoint-creds-updater -r /tmp/config/pip_requirements.txt

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -19,11 +19,14 @@ RUN \
     # Add jupyter*config*.py
     && cp /tmp/config/jupyter*config*.py /etc/jupyter/ \
     && mkdir /etc/jupyter/labconfig/ \
-    && cp /tmp/config/*.json /etc/jupyter/labconfig/
+    && cp /tmp/config/*.json /etc/jupyter/labconfig/ \
+    # Autoload extension in IPython kernel config
+    && mkdir -p /etc/ipython \
+    && echo "c.IPKernelApp.extensions = ['ipython_datajoint_creds_updater.extension']" > /etc/ipython/ipython_kernel_config.py
 
 USER $NB_UID
 RUN \
     # remove default work directory
     [ -d "/home/jovyan/work" ] && rm -r /home/jovyan/work \
     # Install dependencies: pip
-    && pip install /tmp/ipython-datajoint-creds-updater -r /tmp/config/pip_requirements.txt
+    && pip install /tmp/ipython-datajoint-creds-updater -r /tmp/config/pip_requirements.txt jupyter_contrib_nbextensions


### PR DESCRIPTION
https://datajoint.atlassian.net/browse/DEV-520

Already in use and deployed on prod and QA CodeBook as of https://github.com/datajoint-company/dj-gitops/pull/343/commits/9678479528501caac8d99dfde2056f7c0a2dcdaa

I mistakenly believed that we could configure the singleuser pod to auto-start the `ipython_datajoint_creds_updater` ipython extension on pod start. I realized the correct way to do this is by changing the singleuser Docker image, which is the change in this PR.