### PR TITLE
PLAT-973 + PLAT-974: parameterize Keycloak host, add Python 3.12 IDE variant

### DIFF
--- a/.github/workflows/singleuser-release.yaml
+++ b/.github/workflows/singleuser-release.yaml
@@ -53,8 +53,13 @@ jobs:
   release-image-ide:
     if: github.event.inputs.dockerfile_name == 'IDE.Dockerfile'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - py_ver: '3.11'
+          - py_ver: '3.12'
     env:
-      PYTHON_VERSION: '3.11'
+      PYTHON_VERSION: ${{matrix.py_ver}}
       JUPYTERHUB_VERSION: ${{github.event.inputs.jupyterhub_version}}
       DOCKERFILE_NAME: ${{github.event.inputs.dockerfile_name}}
       IMAGE_SUFFIX: '-ide'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Table of Contents
   - [Introduction](#introduction)
   - [Quick Start](#quick-start)
+  - [Hub configuration env vars](#hub-configuration-env-vars)
   - [Build Jupyterhub Singleuser Image](#build-jupyterhub-singleuser-image)
     - [Configuration](#configuration)
     - [Build](#build)
@@ -22,6 +23,20 @@ Directory explain:
 - `~/legacy` contains the old implementation of the image
 - `~/singleuser` is used to build the jupyterhub profile images
 - `~/hub` is a Docker based jupyterhub host server using DockerSpawner and Docker-in-Docker to launch jupyterhub singleuser server as a Docker container, in order to locally validate the singleuser images for development purpose.(**Don't recommend to use this in production, due to the security concern of Docker-in-Docker**)
+
+
+## Hub configuration env vars
+
+The hub image (`hub/config/jupyterhub_config.py`) requires the following environment variables at startup:
+
+| Env var | Description | Example |
+|---------|-------------|---------|
+| `OAUTH2_CLIENT_ID` | Keycloak client ID | `codebook` |
+| `OAUTH2_CLIENT_SECRET` | Keycloak client secret | (secret) |
+| `KEYCLOAK_HOST` | Keycloak hostname, no scheme | `keycloak.datajoint.com` |
+| `OAUTH_CALLBACK_URL` | Fully-qualified OAuth callback URL | `https://codebook.datajoint.com/hub/oauth_callback` |
+
+The container will fail to start if any of these are unset.
 
 
 ## Build Jupyterhub Singleuser Image

--- a/hub/config/jupyterhub_config.py
+++ b/hub/config/jupyterhub_config.py
@@ -101,12 +101,24 @@ class RefreshingAuthenticator(GenericOAuthenticator):
 c.JupyterHub.ssl_key = '/etc/letsencrypt/live/fakeservices.datajoint.io/privkey.pem'
 c.JupyterHub.ssl_cert = '/etc/letsencrypt/live/fakeservices.datajoint.io/fullchain.pem'
 c.JupyterHub.authenticator_class = RefreshingAuthenticator
-c.GenericOAuthenticator.client_id = os.getenv("OAUTH2_CLIENT_ID")
-c.GenericOAuthenticator.client_secret = os.getenv("OAUTH2_CLIENT_SECRET")
-c.GenericOAuthenticator.oauth_callback_url = "https://127.0.0.1:8000/hub/oauth_callback"
-c.GenericOAuthenticator.authorize_url = "https://keycloak-qa.datajoint.io/realms/datajoint/protocol/openid-connect/auth"
-c.GenericOAuthenticator.token_url = "https://keycloak-qa.datajoint.io/realms/datajoint/protocol/openid-connect/token"
-c.GenericOAuthenticator.userdata_url = "https://keycloak-qa.datajoint.io/realms/datajoint/protocol/openid-connect/userinfo"
+c.GenericOAuthenticator.client_id = os.environ["OAUTH2_CLIENT_ID"]
+c.GenericOAuthenticator.client_secret = os.environ["OAUTH2_CLIENT_SECRET"]
+
+# Keycloak host and OAuth callback URL come from environment so the hub image
+# is reusable across environments. Set KEYCLOAK_HOST to the keycloak hostname
+# (e.g. "keycloak.datajoint.com"), no scheme. OAUTH_CALLBACK_URL must be a
+# fully-qualified HTTPS URL.
+#
+# Known residual risks (not yet addressed): verify=False is still in effect
+# on the OAuth callback (see TODO above), and jupyter_codeserver_proxy is on
+# its 1.0b3 beta pin.
+_keycloak_host = os.environ["KEYCLOAK_HOST"]
+_realm_path = "realms/datajoint/protocol/openid-connect"
+c.GenericOAuthenticator.oauth_callback_url = os.environ["OAUTH_CALLBACK_URL"]
+c.GenericOAuthenticator.authorize_url = f"https://{_keycloak_host}/{_realm_path}/auth"
+c.GenericOAuthenticator.token_url = f"https://{_keycloak_host}/{_realm_path}/token"
+c.GenericOAuthenticator.userdata_url = f"https://{_keycloak_host}/{_realm_path}/userinfo"
+c.GenericOAuthenticator.logout_redirect_url = f"https://{_keycloak_host}/{_realm_path}/logout"
 c.GenericOAuthenticator.login_service = "Datajoint"
 c.GenericOAuthenticator.username_claim = "preferred_username"
 c.GenericOAuthenticator.enable_auth_state = True


### PR DESCRIPTION
## Summary

Two djlabhub-docker hardening items for [PLAT-590](https://datajoint.atlassian.net/browse/PLAT-590):

- [PLAT-973](https://datajoint.atlassian.net/browse/PLAT-973): the hub image's `jupyterhub_config.py` hardcoded `keycloak-qa.datajoint.io` and the localhost OAuth callback. Replaced with required env vars `KEYCLOAK_HOST` and `OAUTH_CALLBACK_URL`. The container fails to start if either is unset.
- [PLAT-974](https://datajoint.atlassian.net/browse/PLAT-974): `release-image-ide` workflow now uses a matrix to build both Python 3.11 and 3.12 IDE images.

## Why now

DJ IDE phase-2 production deployment ([PLAT-590](https://datajoint.atlassian.net/browse/PLAT-590)) needs the hub image to work outside QA. The hardcoded Keycloak host was a blocker for any non-QA deployment of this image. Python 3.12 proves the multi-version build pattern without committing to a full matrix.

## Note on PLAT-973 scope

The ticket originally referenced `dj-gitops/.../codebook/config/jupyterhub_config.py` — that file no longer has the hardcoding (cleaned up by the recent ArgoCD migration; all OAuth URLs now live in env-specific `values-{env}.yaml`). The remaining hardcoding is in this repo (djlabhub-docker), matching the architecture-doc gap #7 wording. Retargeted accordingly.

## Out of scope

- `verify=False` on OAuth callback — deferred until a real cert is available.
- `jupyter_codeserver_proxy-1.0b3` beta pin — deferred until upstream GA.
- Full Python version matrix (3.8–3.10 for IDE) — no demand today.

## Test plan

- **Docker build (local):** `docker build --build-arg JUPYTERHUB_VERSION=4.0.2 -t djlabhub-hub-smoke -f hub/Dockerfile hub/` — succeeded.
- **Config import (happy path):** ran the config inside the built image with all four env vars set (`OAUTH2_CLIENT_ID`, `OAUTH2_CLIENT_SECRET`, `KEYCLOAK_HOST=keycloak.example.com`, `OAUTH_CALLBACK_URL=https://codebook.example.com/hub/oauth_callback`). Verified the constructed URLs:
  - `authorize_url = https://keycloak.example.com/realms/datajoint/protocol/openid-connect/auth`
  - `logout_redirect_url = https://keycloak.example.com/realms/datajoint/protocol/openid-connect/logout`
  - `oauth_callback_url = https://codebook.example.com/hub/oauth_callback`
- **Fail-fast (missing env vars):** confirmed that running with `KEYCLOAK_HOST` unset raises `KeyError: 'KEYCLOAK_HOST'` at import; running with no env vars at all raises `KeyError: 'OAUTH2_CLIENT_ID'`. Container would fail to start, as designed.
- **Workflow lint:** ran `rhysd/actionlint` against `.github/workflows/singleuser-release.yaml`. No new errors. Only diagnostics are pre-existing `docker/login-action@v2` "runner too old" warnings on lines 43 and 72 — out of scope for this PR.
- **No naked-python validation** — djlabhub-docker has no Python dependency manager (Docker-build-only repo); all validation was via the built hub image.

## Deployment

When this image is pulled into a JupyterHub deployment (dj-gitops codebook), the Helm values must set `KEYCLOAK_HOST` and `OAUTH_CALLBACK_URL` in `hub.extraEnv`. Update needed in `dj-gitops/applications/k8s/argocd/apps-values/codebook/values-{env}.yaml` if/when this image starts being used in a path where these are not already set elsewhere.

[PLAT-590]: https://datajoint.atlassian.net/browse/PLAT-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-973]: https://datajoint.atlassian.net/browse/PLAT-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-974]: https://datajoint.atlassian.net/browse/PLAT-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-590]: https://datajoint.atlassian.net/browse/PLAT-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ